### PR TITLE
Feature: Trigger gitlab pipeline through api

### DIFF
--- a/.github/workflows/trigger-deployment.yml
+++ b/.github/workflows/trigger-deployment.yml
@@ -14,7 +14,8 @@ jobs:
         run: |
           curl -X POST "$GITLAB_TRIGGER_URL" \
             -F token="$GITLAB_TRIGGER_TOKEN" \
-            -F ref=main
+            -F ref=main \
+            -F "variables[DEPLOY_ENV]=stage"
         env:
           GITLAB_TRIGGER_URL: ${{ secrets.GITLAB_TRIGGER_URL }}
           GITLAB_TRIGGER_TOKEN: ${{ secrets.GITLAB_TRIGGER_TOKEN }}

--- a/.github/workflows/trigger-deployment.yml
+++ b/.github/workflows/trigger-deployment.yml
@@ -4,6 +4,9 @@ name: Trigger GitLab Deploy Project
 on:
   push:
     branches:
+      - main
+      - stage
+      - devlopment
       - gitlab_api_trigger
 
 jobs:
@@ -12,7 +15,7 @@ jobs:
     steps:
       - name: Trigger GitLab deployment_agroportal pipeline
         run: |
-          curl -X POST "$GITLAB_TRIGGER_URL" \
+          curl --fail --silent --show-error -X POST "$GITLAB_TRIGGER_URL" \
             -F token="$GITLAB_TRIGGER_TOKEN" \
             -F ref=main \
             -F "variables[DEPLOY_ENV]=stage"

--- a/.github/workflows/trigger-deployment.yml
+++ b/.github/workflows/trigger-deployment.yml
@@ -1,0 +1,20 @@
+# .github/workflows/trigger-deployment.yml
+name: Trigger GitLab Deploy Project
+
+on:
+  push:
+    branches:
+      - gitlab_api_trigger
+
+jobs:
+  trigger-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger GitLab deployment_agroportal pipeline
+        run: |
+          curl -X POST "$GITLAB_TRIGGER_URL" \
+            -F token="$GITLAB_TRIGGER_TOKEN" \
+            -F ref=main
+        env:
+          GITLAB_TRIGGER_URL: ${{ secrets.GITLAB_TRIGGER_URL }}
+          GITLAB_TRIGGER_TOKEN: ${{ secrets.GITLAB_TRIGGER_TOKEN }}

--- a/.github/workflows/trigger-deployment.yml
+++ b/.github/workflows/trigger-deployment.yml
@@ -13,6 +13,11 @@ jobs:
   trigger-deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: test connectivity
+        run: |
+          nslookup forge-dsi.dcidf.inrae.fr || true
+          curl -v https://forge-dsi.dcidf.inrae.fr/ || true
+
       - name: Trigger GitLab deployment_agroportal pipeline
         run: |
           curl --fail --silent --show-error -X POST "$GITLAB_TRIGGER_URL" \


### PR DESCRIPTION
### Workflow
<img width="1030" height="577" alt="image" src="https://github.com/user-attachments/assets/656dc38a-3bd3-43af-8691-a188739cbcae" />

### Screenshots
- Github
<img width="945" height="278" alt="image" src="https://github.com/user-attachments/assets/f97f743a-b1b2-40bb-8586-72ce7e6dae9b" />

- Gitlab
<img width="1330" height="270" alt="image" src="https://github.com/user-attachments/assets/2616aad6-a94e-44a8-aa7b-de122ce66b8c" />


### TO-DO
- configure the project in gitlab to do the deployment
- test it with the INRAE forge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated deployment trigger integrating GitHub and GitLab. Pushes to main, stage, and development branches start a deployment pipeline (defaults to staging). Uses encrypted secrets for configuration. Reduces manual steps and accelerates feedback cycles for releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->